### PR TITLE
The Buck stops here.

### DIFF
--- a/snipcart/templates/customer.twig
+++ b/snipcart/templates/customer.twig
@@ -54,7 +54,7 @@
 				
 				<h3>Orders</h3>
 
-				<p>{{ customer.statistics.ordersCount }} order{% if customer.statistics.ordersCount != 1 %}s{% endif %}, ${{ customer.statistics.ordersAmount | number_format(2) }} spent</p>
+				<p>{{ customer.statistics.ordersCount }} order{% if customer.statistics.ordersCount != 1 %}s{% endif %}, {{ customer.statistics.ordersAmount }} spent</p>
 
 				<table class="data" style="width: 100%">
 					<thead>
@@ -72,7 +72,7 @@
 								{{ order.creationDate | date('n/j/Y') }}
 							</td>
 							<td>
-								${{ order.finalGrandTotal | number_format(2) }}
+								{{ order.finalGrandTotal | currency(order.currency|upper) }}
 							</td>
 						</tr>
 						{% endfor %}

--- a/snipcart/templates/customers.twig
+++ b/snipcart/templates/customers.twig
@@ -50,7 +50,7 @@
 						<td>{{ customer.billingAddressAddress1 }}</td>
 						<td>{{ customer.shippingAddressAddress1 }}</td>
 						<td>{{ customer.statistics.ordersCount }}</td>
-						<td>${{ customer.statistics.ordersAmount | number_format(2) }}</td>
+						<td>{{ customer.statistics.ordersAmount | number_format(2) }}</td>
 					</tr>
 				{% endfor %}
 			</tbody>

--- a/snipcart/templates/email.twig
+++ b/snipcart/templates/email.twig
@@ -1,4 +1,4 @@
-<p>{{ order.cardHolderName }} ({{ order.email }}) just placed order {{ order.invoiceNumber }} for ${{ order.finalGrandTotal }}:</p>
+<p>{{ order.cardHolderName }} ({{ order.email }}) just placed order {{ order.invoiceNumber }} for {{ order.finalGrandTotal | currency(order.currency|upper) }}:</p>
 
 <hr style="height: 0; border-top: 1px solid #ddd; color: #ddd; background: #ddd;">
 
@@ -6,7 +6,7 @@
 <ul>
 {% for item in order.items %}
 	<li>
-		<span style="color: #666;">{{ item.quantity }}x</span> {{ item.name }} @ ${{ item.price }}
+		<span style="color: #666;">{{ item.quantity }}x</span> {{ item.name }} @ {{ item.price | currency(order.currency|upper) }}
 		{%- if item.customFields | length -%}
 			({% for field in item.customFields -%}
 			    {{ field.name }}: {{ field.value }}{% if loop.last != true %},{% endif %}
@@ -64,7 +64,7 @@
 
 <hr style="height: 0; border-top: 1px solid #ddd; color: #ddd; background: #ddd;">
 
-<h3>Shipping Method: {{ order.shippingMethod }} (${{ order.shippingFees }})</h3>
+<h3>Shipping Method: {{ order.shippingMethod }} ({{ order.shippingFees | currency(order.currency|upper) }})</h3>
 
 <hr style="height: 0; border-top: 1px solid #ddd; color: #ddd; background: #ddd;">
 

--- a/snipcart/templates/index.twig
+++ b/snipcart/templates/index.twig
@@ -89,7 +89,7 @@
 						<td>{{ order.creationDate | date('n/j/Y') }}</td>
 						<td>{{ order.cardHolderName }}</td>
 						<td><a href="mailto:{{ order.email }}">{{ order.email }}</a></td>
-						<td>${{ order.finalGrandTotal | number_format(2) }}</td>
+						<td>{{ order.finalGrandTotal | currency(order.currency|upper) }}</td>
 						<td>
 							{% if order.status == "Open" %}
 							<div class="status"></div>

--- a/snipcart/templates/order.twig
+++ b/snipcart/templates/order.twig
@@ -114,7 +114,7 @@
 
 						</td>
 						<td style="text-align: right;">
-							${{ item.price | number_format(2) }}
+							{{ item.price | currency(order.currency|upper) }}
 						</td>
 						{#
 						{{ item.uniqueId }}
@@ -145,7 +145,7 @@
 						Subtotal
 					</td>
 					<td style="text-align: right;">
-						${{ order.subtotal | number_format(2) }}
+						{{ order.subtotal | currency(order.currency|upper) }}
 					</td>
 				</tr>
 				<tr>
@@ -153,7 +153,7 @@
 						Shipping
 					</td>
 					<td style="text-align: right;">
-						${{ order.shippingFees | number_format(2) }} via {{ order.shippingMethod }} ({{ order.totalWeight }} grams)
+						{{ order.shippingFees | currency(order.currency|upper) }} via {{ order.shippingMethod }} ({{ order.totalWeight }} grams)
 					</td>
 				</tr>
 				{% for tax in order.taxes %}
@@ -162,7 +162,7 @@
 						{{ tax.taxName }} ({{ tax.taxRate }})
 					</td>
 					<td style="text-align: right;">
-						${{ tax.amount | number_format(2) }}
+						{{ tax.amount | currency(order.currency|upper) }}
 						{# {{ tax.numberForInvoice }} #}
 					</td>
 				</tr>
@@ -182,7 +182,7 @@
 						Total Rebates
 					</td>
 					<td style="text-align: right;">
-						${{ order.rebateAmount | number_format(2) }}
+						{{ order.rebateAmount | currency(order.currency|upper) }}
 					</td>
 				</tr>
 				{% endif %}
@@ -191,7 +191,7 @@
 						<b>Grand Total</b>
 					</td>
 					<td style="text-align: right;">
-						<b>${{ order.finalGrandTotal | number_format(2) }}</b>
+						<b>{{ order.finalGrandTotal | currency(order.currency|upper) }}</b>
 					</td>
 				</tr>
 			</table>


### PR DESCRIPTION
For if your not trading in dollar dollar bill y'all, this replaces the $ with relevant currency symbol, as provided by the orders response.

Note the customer API call doesn't actually indicate the currency for its statistics.ordersAmount. In theory you could set it to a recent order.currency value, but as snipcart does actually accept multiple currencies, not 100% sure this would always be true, and seemed better to indicate no symbol than the wrong one?