### PR TITLE
Multi locale date handling, devMode twig error

### DIFF
--- a/snipcart/SnipcartPlugin.php
+++ b/snipcart/SnipcartPlugin.php
@@ -11,7 +11,7 @@ class SnipcartPlugin extends BasePlugin
 
 	public function getVersion()
 	{
-		return '0.9.5';
+		return '0.9.6';
 	}
 
 	public function getDeveloper()

--- a/snipcart/services/SnipcartService.php
+++ b/snipcart/services/SnipcartService.php
@@ -175,10 +175,12 @@ class SnipcartService extends BaseApplicationComponent
 		$stored    = craft()->httpSession->get('snipcartStartDate');
 		$startDate = $default;
 
-		if ($param)
-			$startDate = strtotime($param['date'])+86400;
-		else
+		if ($param) {
+			$startDate = new DateTime();
+			$startDate = strtotime($startDate->createFromString($param)->format('Y-m-d H:i:s'));
+		} else {
 			$startDate = $stored ? $stored : $default;
+	    }
 
 		craft()->httpSession->add('snipcartStartDate', $startDate);
 
@@ -193,10 +195,12 @@ class SnipcartService extends BaseApplicationComponent
 		$stored    = craft()->httpSession->get('snipcartEndDate');
 		$endDate = $default;
 
-		if ($param)
-			$endDate = strtotime($param['date'])+86400;
-		else
+		if ($param) {
+			$endDate = new DateTime();
+			$endDate = strtotime($endDate->createFromString($param)->format('Y-m-d H:i:s'));
+		} else {
 			$endDate = $stored ? $stored : $default;
+	    }
 
 		craft()->httpSession->add('snipcartEndDate', $endDate);
 

--- a/snipcart/templates/order.twig
+++ b/snipcart/templates/order.twig
@@ -176,7 +176,7 @@
 				</tr>
 				{% endfor %}
 				{% endif %}
-				{% if order.rebateAmount %}
+				{% if order.rebateAmount is defined %}
 				<tr>
 					<td>
 						Total Rebates


### PR DESCRIPTION
Hi,

I hit a couple of issues using this plugin on a British site. The main issue was around the date search which I realised was due to the different date format not being accepted by `strtotime`, so I used Craft's `createFromString()` helper function to create a `DateTime` object and standardise the format.

The second was just a twig error while trying to view an order in `devMode` which seemed to be missing a `is defined` check.

Thanks,

Mark